### PR TITLE
Update HttpClient.class.php

### DIFF
--- a/HttpClient.class.php
+++ b/HttpClient.class.php
@@ -134,6 +134,7 @@ class HttpClient {
         $this->path = $this->orig_path;
 
         $this->postdata = null;
+        return $result;
     }
 
     public function post($path, $data, $headers=array()) {
@@ -164,6 +165,7 @@ class HttpClient {
         $this->path = $orig_path;
 
         $this->postdata = null;
+        return $result;
     }
 
     public function put($path, $data, $headers=array()) {
@@ -194,6 +196,7 @@ class HttpClient {
         $this->path = $orig_path;
 
         $this->postdata = null;
+        return $result;
     }
 
     public function delete($path, $data, $headers=array()) {
@@ -221,6 +224,7 @@ class HttpClient {
         $this->path = $orig_path;
 
         $this->postdata = null;
+        return $result;
     }
 
     public function buildQuery($data) {


### PR DESCRIPTION
Added "return $result" to the methods get(), post(), put() and delete(), so the following example will work again:

$client = new HttpClient('example.com');
if (!$client->get('/')) {
    die('An error occurred: '.$client->getError());
}
$pageContents = $client->getContent();
