### PR TITLE
Update HttpClient.class.php

### DIFF
--- a/HttpClient.class.php
+++ b/HttpClient.class.php
@@ -298,8 +298,8 @@ class HttpClient {
 
     public function getRequestURL() {
         // Returns the full URL that has been requested.
-        $url = 'http://'.$this->host;
-        if ($this->port != 80) {
+        $url = $this->scheme.'://'.$this->host;
+        if ($this->port != 80 && $this->scheme != 'https' || ($this->port != 443 && $this->scheme == 'https')) {        
             $url .= ':'.$this->port;
         }
         $url .= $this->path;


### PR DESCRIPTION
Fixed getRequestURL() for https and https default port (443), avoiding "CSRF verification failed" when persist_referers is true.
