### PR TITLE
remove reference to local  (it is null) and instead rely on default empt...

### DIFF
--- a/HttpClient.class.php
+++ b/HttpClient.class.php
@@ -455,7 +455,7 @@ class HttpClient {
         */
 
         $client = self::create($url);
-        $client->get($client->getPath(), $data, $headers);
+        $client->get($client->getPath(), $data);
         return $client;
 
     }
@@ -465,7 +465,7 @@ class HttpClient {
         // Similar to [HttpClient::quickGet()], but performs a POST query.
 
         $client = self::create($url);
-        $client->post($client->getPath(), $data, $headers);
+        $client->post($client->getPath(), $data);
         return $client;
 
     }


### PR DESCRIPTION
Removed reference to local $header variable in both quickGet and quickPost and changed respectively get/post calls to 2 argument versions so that default value of empty array is used.
